### PR TITLE
Add pulseaudio backend.

### DIFF
--- a/src/audio.py
+++ b/src/audio.py
@@ -130,7 +130,7 @@ class Player(object):
     def __init__(self, output_device='default'):
         self._output_device = output_device
 
-    def play_bytes(self, audio_bytes, sample_rate, sample_width=2):
+    def play_bytes(self, audio_bytes, sample_rate_hz, bytes_per_sample=2):
         """Play audio from the given bytes-like object.
 
         audio_bytes: audio data (mono)
@@ -144,8 +144,8 @@ class Player(object):
             '-t', 'raw',
             '-D', self._output_device,
             '-c', '1',
-            '-f', sample_width_to_string(sample_width),
-            '-r', str(sample_rate),
+            '-f', sample_width_to_string(bytes_per_sample),
+            '-r', str(sample_rate_hz),
         ]
 
         aplay = subprocess.Popen(cmd, stdin=subprocess.PIPE)

--- a/src/main.py
+++ b/src/main.py
@@ -110,6 +110,8 @@ def main():
     parser = configargparse.ArgParser(
         default_config_files=CONFIG_FILES,
         description="Act on voice commands using Google's speech recognition")
+    parser.add_argument('-B', '--audio-backend', default='alsa',
+                        help='Name of the audio backend {\'alsa\', \'pulse\'}')
     parser.add_argument('-I', '--input-device', default='default',
                         help='Name of the audio input device')
     parser.add_argument('-O', '--output-device', default='default',
@@ -137,7 +139,7 @@ def main():
     create_pid_file(args.pid_file)
     i18n.set_language_code(args.language, gettext_install=True)
 
-    player = audio.Player(args.output_device)
+    player = audio.Player(args.audio_backend, args.output_device)
 
     if args.cloud_speech:
         credentials_file = os.path.expanduser(args.cloud_speech_secrets)
@@ -150,7 +152,7 @@ def main():
         recognizer = speech.AssistantSpeechRequest(credentials)
 
     recorder = audio.Recorder(
-        input_device=args.input_device, channels=1,
+        backend=args.audio_backend, input_device=args.input_device, channels=1,
         bytes_per_sample=speech.AUDIO_SAMPLE_SIZE,
         sample_rate_hz=speech.AUDIO_SAMPLE_RATE_HZ)
     with recorder:

--- a/src/main.py
+++ b/src/main.py
@@ -292,8 +292,8 @@ class SyncMicRecognizer(object):
         sample_rate_hz = speech.AUDIO_SAMPLE_RATE_HZ
         logger.info('Playing %.4f seconds of audio...',
                     len(audio_bytes) / (bytes_per_sample * sample_rate_hz))
-        self.player.play_bytes(audio_bytes, sample_width=bytes_per_sample,
-                               sample_rate=sample_rate_hz)
+        self.player.play_bytes(audio_bytes, bytes_per_sample=bytes_per_sample,
+                               sample_rate_hz=sample_rate_hz)
 
 
 if __name__ == '__main__':

--- a/src/tts.py
+++ b/src/tts.py
@@ -96,7 +96,7 @@ def say(player, words, eq_filter=None, lang='en-US'):
     eq_audio = np.clip(eq_audio, int16_info.min, int16_info.max)
     eq_bytes = eq_audio.astype(np.int16).tostring()
 
-    player.play_bytes(eq_bytes, sample_rate=SAMPLE_RATE)
+    player.play_bytes(eq_bytes, sample_rate_hz=SAMPLE_RATE)
 
 
 def main():


### PR DESCRIPTION
On Ubuntu my microphone is configured as the default pulseaudio source. Only by suspending pulse (which stops all other apps from making sound) can arecord access it. This patch allows to select audio backend with -B alsa or -B pulse. parecord and paplay are directly substituted for arecord and aplay (the command lines are hardly different.)

A cleanup of inconsistent variable names between Player and Recorder is also included.

This could be improved further by implementing device selection (-I and -O) for pulseaudio. Currently it can only use the default which is probably what most people want.

Is this something you would even be interested in?