### PR TITLE
Properly encode UTF-8 input passed to pico2wave

### DIFF
--- a/src/tts.py
+++ b/src/tts.py
@@ -80,7 +80,7 @@ def say(player, words, eq_filter=None, lang='en-US'):
     os.close(fd)
 
     try:
-        subprocess.call(['pico2wave', '-l', lang, '-w', raw_wav, words])
+        subprocess.call(['pico2wave', '-l', lang, '-w', raw_wav, words.encode("utf-8")])
         with wave.open(raw_wav, 'rb') as f:
             raw_bytes = f.readframes(f.getnframes())
     finally:


### PR DESCRIPTION
Without this fix, the following issue occurs when a non-ASCII input is passed to the "say" method. In this case I told the device "stop", after which the Google Assistant API returns "I don\u2019t know how to answer that" (note the \u2019, i.e. the "right single quotation mark"). With the fix it works properly.

It seems that subprocess.call ends up calling native CPython code, where all arguments are passed to PyUnicode_FSConverter, which tries to encode each string using the PyUnicode_EncodeFSDefault() encoding. In this case that encoding seems to be ASCII, which then causes the error. When we do the encoding to bytes ourselves ahead of time then PyUnicode_FSConverter will just return those bytes as is, thereby avoiding the error.

Logs showing the error:
[2017-05-06 18:22:51,403] INFO:trigger:clap detected
[2017-05-06 18:22:51,405] INFO:main:listening...
[2017-05-06 18:22:51,406] INFO:main:recognizing...
[2017-05-06 18:22:54,058] INFO:speech:event_type: 1
[2017-05-06 18:22:54,060] INFO:main:thinking...
[2017-05-06 18:22:54,063] INFO:speech:transcript: stop
[2017-05-06 18:22:54,114] WARNING:main:'stop' was not handled
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.4/threading.py", line 868, in run
    self._target(*self._args, **self._kwargs)
  File "src/main.py", line 269, in _recognize
    self._handle_result(self.recognizer.do_request())
  File "src/main.py", line 285, in _handle_result
    self.say(_("I don\u2019t know how to answer that."))
  File "/home/pi/voice-recognizer-raspi/src/tts.py", line 83, in say
    print(words)
UnicodeEncodeError: 'ascii' codec can't encode character '\u2019' in position 5: ordinal not in ran
ge(128)