### PR TITLE
Don't hardcode the path to the repo

### DIFF
--- a/checkpoints/check_audio.py
+++ b/checkpoints/check_audio.py
@@ -32,7 +32,7 @@ INACTIVE_STR = 'ActiveState=inactive'
 
 STOP_DELAY = 1.0
 
-VOICE_RECOGNIZER_PATH = '/home/pi/voice-recognizer-raspi'
+VOICE_RECOGNIZER_PATH = os.path.realpath(os.path.join(__file__, '..', '..'))
 PYTHON3 = 'python3'
 AUDIO_PY = VOICE_RECOGNIZER_PATH + '/src/audio.py'
 

--- a/checkpoints/check_cloud.py
+++ b/checkpoints/check_cloud.py
@@ -27,7 +27,7 @@ if os.path.exists('/home/pi/credentials.json'):
 else:
     CREDENTIALS_PATH = '/home/pi/cloud_speech.json'
 
-VOICE_RECOGNIZER_PATH = '/home/pi/voice-recognizer-raspi'
+VOICE_RECOGNIZER_PATH = os.path.realpath(os.path.join(__file__, '..', '..'))
 PYTHON3 = VOICE_RECOGNIZER_PATH + '/env/bin/python3'
 SPEECH_PY = VOICE_RECOGNIZER_PATH + '/src/speech.py'
 SPEECH_PY_ENV = {

--- a/checkpoints/load_test.py
+++ b/checkpoints/load_test.py
@@ -35,7 +35,7 @@ INACTIVE_STR = 'ActiveState=inactive'
 
 STOP_DELAY = 1.0
 
-VOICE_RECOGNIZER_PATH = '/home/pi/voice-recognizer-raspi'
+VOICE_RECOGNIZER_PATH = os.path.realpath(os.path.join(__file__, '..', '..'))
 PYTHON3 = VOICE_RECOGNIZER_PATH + '/env/bin/python3'
 AUDIO_PY = VOICE_RECOGNIZER_PATH + '/src/audio.py'
 SPEECH_PY = VOICE_RECOGNIZER_PATH + '/src/speech.py'

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -23,12 +23,14 @@ then
     exec sudo -u $RUN_AS $0
 fi
 
+scripts_dir="$(dirname "${BASH_SOURCE[0]}")"
+
 sudo apt-get -y install alsa-utils python3-all-dev python3-pip python3-numpy \
   python3-scipy python3-virtualenv rsync sox libttspico-utils ntpdate
 sudo apt-get -y install -t stretch python3-httplib2 python3-configargparse
 sudo pip3 install --upgrade pip virtualenv
 
-cd ~/voice-recognizer-raspi
+cd "${scripts_dir}/.."
 virtualenv --system-site-packages -p python3 env
 env/bin/pip install google-assistant-sdk[auth_helpers]==0.1.0 \
   grpc-google-cloud-speech-v1beta1==0.14.0 protobuf==3.1.0

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -19,9 +19,11 @@
 set -o errexit
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+repo_path="$PWD"
 
 for service in systemd/*.service; do
-  cp $service /lib/systemd/system/
+  sed "s:/home/pi/voice-recognizer-raspi:${repo_path}:g" "$service" \
+    > "/lib/systemd/system/$(basename "$service")"
 done
 
 # voice-recognizer is not enabled by default, as it doesn't work until


### PR DESCRIPTION
This means things aren't broken if the user clones into
~/aiyprojects-raspbian, for example.