### PR TITLE
Install config files along with deps

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -34,3 +34,10 @@ virtualenv --system-site-packages -p python3 env
 env/bin/pip install google-assistant-sdk[auth_helpers]==0.1.0 \
   grpc-google-cloud-speech-v1beta1==0.14.0 protobuf==3.1.0 \
   configargparse==0.11.0
+
+for config in status-led.ini voice-recognizer.ini; do
+  if [[ ! -f "${HOME}/.config/${config}" ]] ; then
+    echo "Installing ${config}"
+    cp "config/${config}.default" "${HOME}/.config/${config}"
+  fi
+done


### PR DESCRIPTION
Currently, a user who follows the instructions in HACKING.md won't
install the config files, so they'll run into the crash described in
issue #10. This avoids them being affected by the crash.