### PR TITLE
Add Rpi.GPIO to pip dependencies

### DIFF
--- a/checkpoints/check_wifi.py
+++ b/checkpoints/check_wifi.py
@@ -33,7 +33,7 @@ def check_wifi_is_configured():
 
 def check_wifi_is_connected():
     """Check wlan0 has an IP address."""
-    output = subprocess.check_output(['ifconfig', 'wlan0']).decode('utf-8')
+    output = subprocess.check_output(['sudo', 'ifconfig', 'wlan0']).decode('utf-8')
 
     return 'inet addr' in output
 

--- a/checkpoints/check_wifi.py
+++ b/checkpoints/check_wifi.py
@@ -33,7 +33,7 @@ def check_wifi_is_configured():
 
 def check_wifi_is_connected():
     """Check wlan0 has an IP address."""
-    output = subprocess.check_output(['sudo', 'ifconfig', 'wlan0']).decode('utf-8')
+    output = subprocess.check_output(['ifconfig', 'wlan0']).decode('utf-8')
 
     return 'inet addr' in output
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -27,7 +27,7 @@ scripts_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 sudo apt-get -y install alsa-utils python3-all-dev python3-pip python3-numpy \
   python3-scipy python3-virtualenv rsync sox libttspico-utils ntpdate
-sudo pip3 install --upgrade pip virtualenv Rpi.GPIO
+sudo pip3 install --upgrade pip virtualenv
 
 cd "${scripts_dir}/.."
 virtualenv --system-site-packages -p python3 env

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -27,7 +27,7 @@ scripts_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 sudo apt-get -y install alsa-utils python3-all-dev python3-pip python3-numpy \
   python3-scipy python3-virtualenv rsync sox libttspico-utils ntpdate
-sudo pip3 install --upgrade pip virtualenv
+sudo pip3 install --upgrade pip virtualenv Rpi.GPIO
 
 cd "${scripts_dir}/.."
 virtualenv --system-site-packages -p python3 env


### PR DESCRIPTION
In some systems like mine, the status-led.service required me to install this pip package outside the virtualenv.