### PR TITLE
Add Philips Hue action type

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source = src
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ google-assistant-sdk[auth_helpers]==0.1.0
 grpc-google-cloud-speech-v1beta1==0.14.0
 protobuf==3.1.0
 configargparse==0.11.0
-
+phue==0.9
+rgbxy==0.5

--- a/tests/test_change_light_color.py
+++ b/tests/test_change_light_color.py
@@ -1,0 +1,63 @@
+
+"""Test the change light color action."""
+
+import mock
+import unittest
+
+import phue
+import action
+
+action._ = lambda s: s
+
+
+class TestChangeLightColor(unittest.TestCase):
+
+    def _say(self, text):
+        self._say_text = text
+
+    def setUp(self):
+        self._say_text = None
+
+    @mock.patch("action.phue")
+    def test_change_light_color_no_bridge(self, mockedPhue):
+        mockedPhue.PhueRegistrationException = phue.PhueRegistrationException
+        bridge = mock.MagicMock()
+        bridge.connect.side_effect = mockedPhue.PhueRegistrationException(0, "error")
+        mockedPhue.Bridge.return_value = bridge
+
+        action.ChangeLightColor(self._say, "philips-hue", "Lounge Lamp", "0077be").run()
+
+        self.assertEqual(self._say_text,
+                         "No bridge registered, press button on bridge and try again")
+
+    @mock.patch("action.phue")
+    @mock.patch("action.Converter")
+    def test_change_light_color(self, Converter, mockedPhue):
+
+        xyValue = [0.1, 0.2]
+
+        converter = mock.MagicMock()
+        Converter.return_value = converter
+        converter.hex_to_xy.return_value = xyValue
+
+        light = mock.MagicMock()
+        lights = {
+            "Lounge Lamp": light
+        }
+        bridge = mock.MagicMock()
+        bridge.get_light_objects.return_value = lights
+        mockedPhue.Bridge.return_value = bridge
+
+        action.ChangeLightColor(self._say, "philips-hue", "Lounge Lamp", "0077be").run()
+
+        mockedPhue.Bridge.assert_called_with("philips-hue")
+        bridge.connect.assert_called()
+        bridge.get_light_objects.assert_called_with("name")
+        self.assertEqual(light.on, True)
+        converter.hex_to_xy.assert_called_with("0077be")
+        self.assertEqual(light.xy, xyValue)
+        self.assertEqual(self._say_text, "Ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds Philips hue support using the `phue` library. 

It would be nice to configure the hue bridge in the global configuration file, but I wasn't able to find a nice way to pass this into the `actions.py` class. As such I've forced the user to set it for each actor request. 

Example use where the hostname for my Hue bridge is `philips-hue`. 

`actor.add_keyword(_('change to purple'), ChangeLightColour(say, "philips-hue", "Lounge Lamp", "FFFFbe"))`