### PR TITLE
Update info on HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -2,10 +2,22 @@
 
 We recommend using [the images](https://aiyprojects.withgoogle.com/voice) we
 provide. Those images are based on [Raspbian](https://www.raspberrypi.org/downloads/raspbian/),
-with a few customizations and are tested on the Raspberry Pi 3.
+with a few customizations and are tested on the Raspberry Pi 3. If you prefer
+to setup Raspbian yourself, there are some manual steps you need to take.
 
-If you prefer to setup Raspbian yourself, install the project dependencies and
-setup services:
+## Installing the dependencies
+
+First, make sure you have `git` installed and clone this repository in
+`~/voice-recognizer-raspi`:
+
+```shell
+sudo apt-get install git
+cd
+git clone https://github.com/google/aiyprojects-raspbian.git voice-recognizer-raspi
+```
+
+Then, install the project dependencies and setup the services:
+
 ``` shell
 cd ~/voice-recognizer-raspi
 scripts/install-deps.sh
@@ -16,6 +28,7 @@ sudo scripts/install-services.sh
 
 To use the Voice HAT, you'll need to upgrade your kernel to 4.9, then adjust the
 kernel and ALSA configuration:
+
 ``` shell
 sudo apt-get update
 sudo apt-get install raspberrypi-kernel
@@ -39,7 +52,9 @@ Raspberry Pi by running:
 ``` shell
 make deploy
 ```
+
 To execute the script on the Raspberry Pi run, login to it and run:
+
 ``` shell
 cd ~/voice-recognizer-raspi
 source env/bin/activate
@@ -48,7 +63,7 @@ python3 src/main.py
 
 # I18N
 
-Strings wrapped with `_()` are marked for translation.
+Strings wrapped with `_()` are marked for translation:
 
 ``` shell
 # update catalog after string changed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 This repository contains the source code for the AIYProjects "Voice Kit". See
-https://aiyprojects.withgoogle.com/voice/
+https://aiyprojects.withgoogle.com/voice/.
+
+If you're using Rasbian instead of Google's provided image, read
+[HACKING.md](HACKING.md) for information on getting started.
 
 ## Troubleshooting
 


### PR DESCRIPTION
- Add a reference to HACKING.md in README.md for better discoverability.
- Add new subsection on installing the dependencies: `git` needs to be
  explicitly installed and the directory under which the repository must
  be cloned needs to be specific as it is hardcoded in some scripts.