### PR TITLE
Stay silent when we don't recognize a command

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -284,10 +284,8 @@ class SyncMicRecognizer(object):
             self._play_assistant_response(result.response_audio)
         elif result.transcript:
             logger.warning('%r was not handled', result.transcript)
-            self.say(_("I don’t know how to answer that."))
         else:
             logger.warning('no command recognized')
-            self.say(_("Could you try that again?"))
 
     def _play_assistant_response(self, audio_bytes):
         bytes_per_sample = speech.AUDIO_SAMPLE_SIZE


### PR DESCRIPTION
This is important with the Assistant, as it doesn't always give you an
audio response, even when it handles the command (eg for changing the
volume). It also helps when using the Cloud Speech API, as false
triggers aren't as noticeable if they don't trigger a command.

@ensonic / others, if you think these errors are important for some users, maybe we could hide them behind an option? But I'd prefer to keep it simple if possible.