### PR TITLE
Create /run/user/<uid> when installing services

### DIFF
--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -28,12 +28,6 @@ repo_path="$PWD"
 
 # We want the uid of the user that runs sudo
 userid=$(id -u $SUDO_USER)
-rundir=/run/user/$userid
-
-# Ensure that the directory where the PID is created exists
-if [[ ! -e ${rundir} ]]; then
-  mkdir ${rundir} && chown $SUDO_USER:$SUDO_USER ${rundir}
-fi
 
 # Use systemd-tmpfiles and create the PID directory on boot if it doesn't exist
 sed -e "s:userid:${userid}:;s:username:$SUDO_USER:g" systemd/tmpfiles.d/create-run-dir.conf \

--- a/scripts/install-services.sh
+++ b/scripts/install-services.sh
@@ -26,6 +26,19 @@ fi
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 repo_path="$PWD"
 
+# We want the uid of the user that runs sudo
+userid=$(id -u $SUDO_USER)
+rundir=/run/user/$userid
+
+# Ensure that the directory where the PID is created exists
+if [[ ! -e ${rundir} ]]; then
+  mkdir ${rundir} && chown $SUDO_USER:$SUDO_USER ${rundir}
+fi
+
+# Use systemd-tmpfiles and create the PID directory on boot if it doesn't exist
+sed -e "s:userid:${userid}:;s:username:$SUDO_USER:g" systemd/tmpfiles.d/create-run-dir.conf \
+  > /etc/tmpfiles.d/create-run-dir.conf
+
 for service in systemd/*.service; do
   sed "s:/home/pi/voice-recognizer-raspi:${repo_path}:g" "$service" \
     > "/lib/systemd/system/$(basename "$service")"

--- a/systemd/tmpfiles.d/create-run-dir.conf
+++ b/systemd/tmpfiles.d/create-run-dir.conf
@@ -1,0 +1,1 @@
+D /run/user/userid 0755 username username


### PR DESCRIPTION
If `/run/user/1000` doesn't exist, `voice-recognizer.pid`
cannot be created.

For that reason, we first check if the dir exists, if not,
create it and give it the right ownership, then systemd-tmpfiles
is used to ensure the directory survives a reboot.

Closes https://github.com/google/aiyprojects-raspbian/issues/23