### PR TITLE
Improve sound confirmation code

### DIFF
--- a/src/audio.py
+++ b/src/audio.py
@@ -165,7 +165,7 @@ class Player(object):
 
         with wave.open(wav_path, 'r') as wav:
             if wav.getnchannels() != 1:
-                raise ValueError(wav_path + 'is not a mono file')
+                raise ValueError(wav_path + ' is not a mono file')
 
             frames = wav.readframes(wav.getnframes())
             self.play_bytes(frames, wav.getframerate(), wav.getsampwidth())

--- a/src/main.py
+++ b/src/main.py
@@ -227,9 +227,13 @@ class SyncMicRecognizer(object):
 
         self.running = False
 
-        if trigger_sound and os.path.exists(trigger_sound):
-            self.trigger_sound = trigger_sound
+        if trigger_sound and os.path.exists(os.path.expanduser(trigger_sound)):
+            self.trigger_sound = os.path.expanduser(trigger_sound)
         else:
+            if trigger_sound:
+                logger.warning(
+                    'File %s specified for --trigger-sound does not exist.',
+                    trigger_sound)
             self.trigger_sound = None
 
         if led_fifo and os.path.exists(led_fifo):


### PR DESCRIPTION
Adding some improvments on PR https://github.com/google/aiyprojects-raspbian/pull/60

- Allow for trigger-sound path to start with "\~" by calling `os.path.expanduser` the trigger-sound argument if one exists. If expanduser is called on a string that doesn't start with '~' this results in a [no-op](https://docs.python.org/2/library/os.path.html#os.path.expanduser) and shouldn't affect current behavior
- Add a log message when the trigger-sound argument is present, but does not exist according to os.path.exists to help with debugging.

Random fix I found while coding:
-  Fix spacing of log message in Player.play_wav