### PR TITLE
Use "raspberry" instead of "pi" as power keyword

### DIFF
--- a/src/action.py
+++ b/src/action.py
@@ -284,8 +284,8 @@ def make_actor(say):
     # Makers! Add your own voice commands here.
     # =========================================
 
-    actor.add_keyword(_('pi power off'), PowerCommand(say, 'shutdown'))
-    actor.add_keyword(_('pi reboot'), PowerCommand(say, 'reboot'))
+    actor.add_keyword(_('raspberry power off'), PowerCommand(say, 'shutdown'))
+    actor.add_keyword(_('raspberry reboot'), PowerCommand(say, 'reboot'))
 
     return actor
 


### PR DESCRIPTION
The speech recognition wasn't very good at recognizing "pi" but
"raspberry" seems to work better.

Fixes #69.