### PR TITLE
Fix bug in Stretch where virtualenv command not found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This repository contains the source code for the AIYProjects "Voice Kit". See
 https://aiyprojects.withgoogle.com/voice/.
 
-If you're using Rasbian instead of Google's provided image, read
+If you're using Raspbian instead of Google's provided image, read
 [HACKING.md](HACKING.md) for information on getting started.
 
 [![Build Status](https://travis-ci.org/google/aiyprojects-raspbian.svg?branch=master)](https://travis-ci.org/google/aiyprojects-raspbian/builds)

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -26,8 +26,7 @@ then
 fi
 
 sudo apt-get -y install alsa-utils python3-all-dev python3-pip python3-numpy \
-  python3-virtualenv python3-rpi.gpio python3-pysocks \
-  rsync libttspico-utils ntpdate
+  python3-rpi.gpio python3-pysocks virtualenv rsync libttspico-utils ntpdate
 sudo pip3 install --upgrade pip virtualenv
 
 cd "${scripts_dir}/.."


### PR DESCRIPTION
Fixed a bug in install-deps.sh on Raspbian Stretch (mentioned in #119), where calling virtualenv raises an error saying "command not found".

I believe the cause of the virtualenv issue is that in Jessie, the python3-virtualenv package contains an old version of virtualenv, but install-deps.sh also runs pip to upgrade the virtualenv package, which is when the virtualenv command gets added. In Stretch, the python3-virtualenv package contains the latest version of virtualenv but does not add the command, and the pip command does nothing because the latest version is already installed.

Installing the virtualenv package is an alternative method of adding the command, and it can be substituted in the list of packages for python3-virtualenv because it includes it as a dependency.

Also, I corrected a typo in README.md that I had noticed.