### PR TITLE
Don't forget self

### DIFF
--- a/src/aiy/_drivers/_status_ui.py
+++ b/src/aiy/_drivers/_status_ui.py
@@ -43,7 +43,7 @@ class _StatusUi(object):
                     led_fifo)
             self.led_fifo = None
 
-    def set_trigger_sound_wave(trigger_sound_wave):
+    def set_trigger_sound_wave(self, trigger_sound_wave):
         """Sets the trigger sound.
         A trigger sound is played when the status is 'listening' to indicate
         that the assistant is actively listening to the user.


### PR DESCRIPTION
flake8 testing of https://github.com/google/aiyprojects-raspbian on Python 3.6.2

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./src/aiy/_drivers/_status_ui.py:54:13: F821 undefined name 'self'
            self.trigger_sound_wave = os.path.expanduser(trigger_sound_wave)
            ^

./src/aiy/_drivers/_status_ui.py:60:13: F821 undefined name 'self'
            self.trigger_sound_wave = None
            ^

2       F821 undefined name 'self'
```