### PR TITLE
Add instructions for setting up on Raspbian in voicekit branch.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -26,12 +26,10 @@ sudo scripts/install-services.sh
 
 ## Installing the Voice HAT driver and config
 
-To use the Voice HAT, you'll need to upgrade your kernel to 4.9, then adjust the
-kernel and ALSA configuration:
+To use the Voice HAT, your kernel needs to be 4.9 or later. This is available
+on Raspbian 2017-07-05 and later. You'll also need to configure ALSA:
 
 ``` shell
-sudo apt-get update
-sudo apt-get install raspberrypi-kernel
 sudo scripts/configure-driver.sh
 sudo scripts/install-alsa-config.sh
 sudo reboot
@@ -44,7 +42,7 @@ credentials for cloud APIs. This is documented in the
 [setup instructions](https://aiyprojects.withgoogle.com/voice#users-guide-1-1--connect-to-google-cloud-platform) on the
 webpage.
 
-# Making code changes
+## Making code changes
 
 If you edit the code on a different computer, you can deploy it to your
 Raspberry Pi by running:
@@ -52,6 +50,8 @@ Raspberry Pi by running:
 ``` shell
 make deploy
 ```
+
+## Running automatically
 
 You can find sample scripts in the `src` directory showing how to use the
 Assistant SDK.
@@ -71,25 +71,4 @@ make a copy of one of the sample scripts and rename it. Then run this command:
 
 ``` shell
 sudo systemctl enable voice-recognizer.service
-```
-
-# I18N
-
-Strings wrapped with `_()` are marked for translation:
-
-``` shell
-# update catalog after string changed
-pygettext3 -d voice-recognizer -p po src/main.py src/action.py
-
-# add new language
-msgmerge po/de.po po/voice-recognizer.pot
-# now edit po/de.po
-
-# update language
-msgmerge -U po/de.po po/voice-recognizer.pot
-# now edit po/de.po
-
-# create language bundle
-mkdir po/de/LC_MESSAGES/
-msgfmt po/de.po -o po/de/LC_MESSAGES/voice-recognizer.mo
 ```

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,95 @@
+# Setting up the image
+
+We recommend using [the images](https://aiyprojects.withgoogle.com/voice) we
+provide. Those images are based on [Raspbian](https://www.raspberrypi.org/downloads/raspbian/),
+with a few customizations and are tested on the Raspberry Pi 3. If you prefer
+to setup Raspbian yourself, there are some manual steps you need to take.
+
+## Installing the dependencies
+
+First, make sure you have `git` installed and clone this repository in
+`~/voice-recognizer-raspi`:
+
+```shell
+sudo apt-get install git
+cd
+git clone https://github.com/google/aiyprojects-raspbian.git voice-recognizer-raspi
+```
+
+Then, install the project dependencies and setup the services:
+
+``` shell
+cd ~/voice-recognizer-raspi
+scripts/install-deps.sh
+sudo scripts/install-services.sh
+```
+
+## Installing the Voice HAT driver and config
+
+To use the Voice HAT, you'll need to upgrade your kernel to 4.9, then adjust the
+kernel and ALSA configuration:
+
+``` shell
+sudo apt-get update
+sudo apt-get install raspberrypi-kernel
+sudo scripts/configure-driver.sh
+sudo scripts/install-alsa-config.sh
+sudo reboot
+```
+
+## Get cloud credentials
+
+To access the cloud services you need to register a project and generate
+credentials for cloud APIs. This is documented in the
+[setup instructions](https://aiyprojects.withgoogle.com/voice#users-guide-1-1--connect-to-google-cloud-platform) on the
+webpage.
+
+# Making code changes
+
+If you edit the code on a different computer, you can deploy it to your
+Raspberry Pi by running:
+
+``` shell
+make deploy
+```
+
+You can find sample scripts in the `src` directory showing how to use the
+Assistant SDK.
+
+To execute any of these scripts on the Raspberry Pi, login to it and run
+(replacing the filename with the script you want to run):
+
+``` shell
+cd ~/voice-recognizer-raspi
+source env/bin/activate
+python3 src/assistant_library_demo.py
+```
+
+If you want the voice recognizer service to run automatically when the Pi
+boots, you need to have a file in the `src` directory named `main.py`. You can
+make a copy of one of the sample scripts and rename it. Then run this command:
+
+``` shell
+sudo systemctl enable voice-recognizer.service
+```
+
+# I18N
+
+Strings wrapped with `_()` are marked for translation:
+
+``` shell
+# update catalog after string changed
+pygettext3 -d voice-recognizer -p po src/main.py src/action.py
+
+# add new language
+msgmerge po/de.po po/voice-recognizer.pot
+# now edit po/de.po
+
+# update language
+msgmerge -U po/de.po po/voice-recognizer.pot
+# now edit po/de.po
+
+# create language bundle
+mkdir po/de/LC_MESSAGES/
+msgfmt po/de.po -o po/de/LC_MESSAGES/voice-recognizer.mo
+```

--- a/HACKING.md
+++ b/HACKING.md
@@ -24,7 +24,7 @@ scripts/install-deps.sh
 sudo scripts/install-services.sh
 ```
 
-## Installing the Voice HAT driver and config
+## Configuring the Voice HAT driver
 
 To use the Voice HAT, your kernel needs to be 4.9 or later. This is available
 on Raspbian 2017-07-05 and later. You'll also need to configure ALSA:

--- a/systemd/voice-recognizer.service
+++ b/systemd/voice-recognizer.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=voice recognizer
+After=network.target ntpdate.service
+
+[Service]
+Environment=VIRTUAL_ENV=/home/pi/voice-recognizer-raspi/env
+Environment=PATH=/home/pi/voice-recognizer-raspi/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart=/home/pi/voice-recognizer-raspi/env/bin/python3 -u src/main.py
+WorkingDirectory=/home/pi/voice-recognizer-raspi
+StandardOutput=inherit
+StandardError=inherit
+Restart=always
+User=pi
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR is my attempt to fix #148. I've added back the files `HACKING.md` and `systemd/voice-recognizer.service` which were in the master branch. I also updated the instructions in `HACKING.md` to work with the voicekit branch.

IMO these files are too useful to not be present in the new branch, and having them there doesn't change the way that this project behaves for anyone who doesn't want to use them.

The way the `install-services.sh` script is currently written, it will automatically add any services in the `systemd` folder to the `/lib/systemd/system` folder on the Pi, including `voice-recognizer.service` if it is present. It will also replace any references to `/home/pi` in the service file, updating them to the correct installation folder. However, the service will never run unless it is explicitly enabled by the user.