### PR TITLE
Fixed trigger sound wave null bug when removing trigger sound

### DIFF
--- a/src/aiy/_drivers/_status_ui.py
+++ b/src/aiy/_drivers/_status_ui.py
@@ -53,6 +53,7 @@ class _StatusUi(object):
         """
         if not trigger_sound_wave:
             self._trigger_sound_wave = None
+            return
         expanded_path = os.path.expanduser(trigger_sound_wave)
         if os.path.exists(expanded_path):
             self._trigger_sound_wave = expanded_path


### PR DESCRIPTION
When trying to remove a trigger sound (passing None), it falls through and throws an error when trying to find a None file. Added a return statement to stop this happening.