### PR TITLE
Narrow check for state change in led driver

### DIFF
--- a/src/aiy/_drivers/_led.py
+++ b/src/aiy/_drivers/_led.py
@@ -90,7 +90,7 @@ class LED:
                 running = self.running
             if not running:
                 return
-            if state:
+            if state is not None:
                 if not self._parse_state(state):
                     raise ValueError('unsupported state: %d' % state)
             if self.iterator:


### PR DESCRIPTION
As `state` is checked with `if state`, the valid state change to `0` (LED_OFF) is ignored by the driver.
As a result its not possible to use the LED_OFF state in the `_state_map` of `_status_ui.py`.

Some people would like to turn of the constant flashing of the LED in ready state (`DARK_BEACON`) (#2, #15). This changes makes this as easy as changing the ready state in the state_map.

