### PR TITLE
.asoundrc added to audio configuration

### DIFF
--- a/scripts/.asoundrc
+++ b/scripts/.asoundrc
@@ -1,0 +1,30 @@
+options snd_rpi_googlemihat_soundcard index=0
+
+pcm.softvol {
+    type softvol
+    slave.pcm dmix
+    control {
+        name Master
+        card 0
+    }
+}
+
+pcm.micboost {
+    type route
+    slave.pcm dsnoop
+    ttable {
+        0.0 30.0
+        1.1 30.0
+    }
+}
+
+pcm.!default {
+    type asym
+    playback.pcm "plug:softvol"
+    capture.pcm "plug:micboost"
+}
+
+ctl.!default {
+    type hw
+    card 0
+}

--- a/scripts/install-alsa-config.sh
+++ b/scripts/install-alsa-config.sh
@@ -36,4 +36,5 @@ for rcfile in "$asoundrc" "$global_asoundrc"; do
 done
 
 sudo cp scripts/asound.conf "$global_asoundrc"
+sudo cp scripts/.asoundrc "$asoundrc"
 echo "Installed voiceHAT ALSA config at $global_asoundrc"


### PR DESCRIPTION
The normal audio installation will blank the .asoundrc and just copy the asound.conf. The Raspbian Stretch tends to populate its own .asoundrc, if left empty and it will cause audio rate errors like this one https://github.com/googlesamples/assistant-sdk-python/issues/127
So its advisable to copy .asoundrc as well along with asound.conf.