### PR TITLE
Say hi when ready

### DIFF
--- a/src/assistant_grpc_demo.py
+++ b/src/assistant_grpc_demo.py
@@ -35,6 +35,7 @@ def main():
     with aiy.audio.get_recorder():
         while True:
             status_ui.status('ready')
+            aiy.audio.say('Hi')
             print('Press the button and speak')
             button.wait_for_press()
             status_ui.status('listening')

--- a/src/assistant_library_demo.py
+++ b/src/assistant_library_demo.py
@@ -42,6 +42,7 @@ def process_event(event):
     status_ui = aiy.voicehat.get_status_ui()
     if event.type == EventType.ON_START_FINISHED:
         status_ui.status('ready')
+        aiy.audio.say('Hi')
         if sys.stdout.isatty():
             print('Say "OK, Google" then speak, or press Ctrl+C to quit...')
 

--- a/src/assistant_library_with_button_demo.py
+++ b/src/assistant_library_with_button_demo.py
@@ -70,6 +70,7 @@ class MyAssistant(object):
         status_ui = aiy.voicehat.get_status_ui()
         if event.type == EventType.ON_START_FINISHED:
             status_ui.status('ready')
+            aiy.audio.say('Hi')
             self._can_start_conversation = True
             # Start the voicehat button trigger.
             aiy.voicehat.get_button().on_press(self._on_button_pressed)

--- a/src/assistant_library_with_local_commands_demo.py
+++ b/src/assistant_library_with_local_commands_demo.py
@@ -59,6 +59,7 @@ def process_event(assistant, event):
     status_ui = aiy.voicehat.get_status_ui()
     if event.type == EventType.ON_START_FINISHED:
         status_ui.status('ready')
+        aiy.audio.say('Hi')
         if sys.stdout.isatty():
             print('Say "OK, Google" then speak, or press Ctrl+C to quit...')
 

--- a/src/cloudspeech_demo.py
+++ b/src/cloudspeech_demo.py
@@ -32,6 +32,7 @@ def main():
 
     while True:
         print('Press the button and speak')
+        aiy.audio.say('Hi')
         button.wait_for_press()
         print('Listening...')
         text = recognizer.recognize()


### PR DESCRIPTION
Especially if you are running headless, it is difficult to understand whether the recognizer has started, without looking at the pulsing light. Considering the device sits out of sight, this becomes an even more of an issue in instances like reboots. This PR solves the issue by saying "hi" when the recognizer is ready to accept input.