### PR TITLE
Update to google-assistant-{library,grpc}==0.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-google-assistant-grpc==0.0.2
+google-assistant-grpc==0.1.0
 google-cloud-speech==0.30.0
 google-auth-oauthlib==0.2.0

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -33,7 +33,7 @@ cd "${scripts_dir}/.."
 virtualenv --system-site-packages -p python3 env
 env/bin/pip install -r requirements.txt
 
-# The google-assistant-library is only available on ARMv7.
-if [[ "$(uname -m)" == "armv7l" ]] ; then
-  env/bin/pip install google-assistant-library==0.0.3
+# The google-assistant-library is only available on some platforms.
+if [[ "$(uname -m)" == "armv7l" || "$(uname -m)" == "x86_64" ]] ; then
+  env/bin/pip install google-assistant-library==0.1.0
 fi

--- a/src/aiy/_apis/_speech.py
+++ b/src/aiy/_apis/_speech.py
@@ -36,7 +36,10 @@ except ImportError:
     sys.exit(1)
 
 from google.rpc import code_pb2 as error_code
-from google.assistant.embedded.v1alpha1 import embedded_assistant_pb2
+from google.assistant.embedded.v1alpha1 import (
+    embedded_assistant_pb2,
+    embedded_assistant_pb2_grpc,
+)
 import grpc
 from six.moves import queue
 
@@ -374,7 +377,7 @@ class AssistantSpeechRequest(GenericSpeechRequest):
         self._transcript = None
 
     def _make_service(self, channel):
-        return embedded_assistant_pb2.EmbeddedAssistantStub(channel)
+        return embedded_assistant_pb2_grpc.EmbeddedAssistantStub(channel)
 
     def _create_config_request(self):
         audio_in_config = embedded_assistant_pb2.AudioInConfig(

--- a/src/aiy/assistant/device_helpers.py
+++ b/src/aiy/assistant/device_helpers.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Device registration helpers for the Google Assistant API."""
+
+import json
+import os
+import random
+
+import google.auth.transport
+
+import aiy.assistant.auth_helpers
+
+
+_DEVICE_MODEL = "voice-kit"
+_DEVICE_MANUFACTURER = "AIY Projects"
+_DEVICE_NAME = "Voice Kit"
+_DEVICE_TYPE = "action.devices.types.LIGHT"
+
+_DEVICE_ID_FILE = os.path.join(
+        aiy.assistant.auth_helpers._VR_CACHE_DIR, 'device_id.json')
+
+
+def _get_project_id():
+    with open(aiy.assistant.auth_helpers._ASSISTANT_CREDENTIALS_FILE) as f:
+        client_secrets_data = json.load(f)
+        return client_secrets_data["installed"]["project_id"]
+
+
+def _get_api_url(*args):
+    return "/".join(
+            ("https://embeddedassistant.googleapis.com/v1alpha2/projects",) + args)
+
+def _load_ids(id_path):
+    with open(id_path, 'r') as f:
+        id_data = json.load(f)
+    return id_data["model_id"], id_data["device_id"]
+
+
+def _save_ids(id_path, model_id, device_id):
+    if not os.path.exists(os.path.dirname(id_path)):
+        os.makedirs(os.path.dirname(id_path))
+
+    id_data = {
+            "model_id": model_id,
+            "device_id": device_id,
+    }
+    with open(id_path, 'w') as f:
+        json.dump(id_data, f)
+
+
+def _get_model_id(credentials, session, project_id):
+    model_id = "%s-%s" % (project_id, _DEVICE_MODEL)
+    payload = {
+            "device_model_id": model_id,
+            "project_id": project_id,
+            "device_type": _DEVICE_TYPE,
+            "manifest": {
+                    "manufacturer": _DEVICE_MANUFACTURER,
+                    "product_name": _DEVICE_NAME,
+            },
+    }
+    r = session.post(_get_api_url(project_id, "deviceModels"),
+                     data=json.dumps(payload))
+    if r.status_code == 409:
+        # Already exists: update
+        r = session.put(_get_api_url(project_id, "deviceModels", model_id),
+                        data=json.dumps(payload))
+    r.raise_for_status()
+    return model_id
+
+
+def get_ids(credentials, model_id=None):
+    """get_ids gets a Device ID for use with the Google Assistant SDK.
+
+    It optionally also gets a Device Model ID if one is not given. The IDs are
+    cached on disk so that a device keeps a consistent ID.
+
+    Returns:
+        a tuple: (device_id, model_id)
+    """
+
+    if os.path.exists(_DEVICE_ID_FILE):
+        return _load_ids(_DEVICE_ID_FILE)
+
+    session = google.auth.transport.requests.AuthorizedSession(credentials)
+    project_id = _get_project_id()
+    model_id = model_id or _get_model_id(credentials, session, project_id)
+
+    device_id = "%s-%06d" % (model_id, random.randrange(1000000))
+    payload = {
+            "id": device_id,
+            "model_id": model_id,
+    }
+    r = session.post(_get_api_url(project_id, "devices"),
+                     data=json.dumps(payload))
+    r.raise_for_status()
+
+    _save_ids(_DEVICE_ID_FILE, model_id, device_id)
+    return model_id, device_id
+
+
+if __name__ == "__main__":
+    credentials = aiy.assistant.auth_helpers.get_assistant_credentials()
+    print("ids:", get_ids(credentials))

--- a/src/assistant_library_demo.py
+++ b/src/assistant_library_demo.py
@@ -61,7 +61,7 @@ def process_event(event):
 
 def main():
     credentials = aiy.assistant.auth_helpers.get_assistant_credentials()
-    device_id, model_id = aiy.assistant.device_helpers.get_ids(credentials)
+    model_id, device_id = aiy.assistant.device_helpers.get_ids(credentials)
     with Assistant(credentials, model_id) as assistant:
         for event in assistant.start():
             process_event(event)

--- a/src/assistant_library_demo.py
+++ b/src/assistant_library_demo.py
@@ -28,6 +28,7 @@ import logging
 import sys
 
 import aiy.assistant.auth_helpers
+import aiy.assistant.device_helpers
 import aiy.voicehat
 from google.assistant.library import Assistant
 from google.assistant.library.event import EventType
@@ -60,7 +61,8 @@ def process_event(event):
 
 def main():
     credentials = aiy.assistant.auth_helpers.get_assistant_credentials()
-    with Assistant(credentials) as assistant:
+    device_id, model_id = aiy.assistant.device_helpers.get_ids(credentials)
+    with Assistant(credentials, model_id) as assistant:
         for event in assistant.start():
             process_event(event)
 

--- a/src/assistant_library_with_button_demo.py
+++ b/src/assistant_library_with_button_demo.py
@@ -62,7 +62,7 @@ class MyAssistant(object):
 
     def _run_task(self):
         credentials = aiy.assistant.auth_helpers.get_assistant_credentials()
-        device_id, model_id = aiy.assistant.device_helpers.get_ids(credentials)
+        model_id, device_id = aiy.assistant.device_helpers.get_ids(credentials)
         with Assistant(credentials, model_id) as assistant:
             self._assistant = assistant
             for event in assistant.start():

--- a/src/assistant_library_with_button_demo.py
+++ b/src/assistant_library_with_button_demo.py
@@ -29,6 +29,7 @@ import sys
 import threading
 
 import aiy.assistant.auth_helpers
+import aiy.assistant.device_helpers
 import aiy.voicehat
 from google.assistant.library import Assistant
 from google.assistant.library.event import EventType
@@ -61,7 +62,8 @@ class MyAssistant(object):
 
     def _run_task(self):
         credentials = aiy.assistant.auth_helpers.get_assistant_credentials()
-        with Assistant(credentials) as assistant:
+        device_id, model_id = aiy.assistant.device_helpers.get_ids(credentials)
+        with Assistant(credentials, model_id) as assistant:
             self._assistant = assistant
             for event in assistant.start():
                 self._process_event(event)

--- a/src/assistant_library_with_local_commands_demo.py
+++ b/src/assistant_library_with_local_commands_demo.py
@@ -91,7 +91,7 @@ def process_event(assistant, event):
 
 def main():
     credentials = aiy.assistant.auth_helpers.get_assistant_credentials()
-    device_id, model_id = aiy.assistant.device_helpers.get_ids(credentials)
+    model_id, device_id = aiy.assistant.device_helpers.get_ids(credentials)
     with Assistant(credentials, model_id) as assistant:
         for event in assistant.start():
             process_event(assistant, event)

--- a/src/assistant_library_with_local_commands_demo.py
+++ b/src/assistant_library_with_local_commands_demo.py
@@ -29,6 +29,7 @@ import subprocess
 import sys
 
 import aiy.assistant.auth_helpers
+import aiy.assistant.device_helpers
 import aiy.audio
 import aiy.voicehat
 from google.assistant.library import Assistant
@@ -90,7 +91,8 @@ def process_event(assistant, event):
 
 def main():
     credentials = aiy.assistant.auth_helpers.get_assistant_credentials()
-    with Assistant(credentials) as assistant:
+    device_id, model_id = aiy.assistant.device_helpers.get_ids(credentials)
+    with Assistant(credentials, model_id) as assistant:
         for event in assistant.start():
             process_event(assistant, event)
 


### PR DESCRIPTION
This doesn't update from v1alpha1 of the gRPC API to v1alpha2, which is to follow, but appears to be mostly search-and-replace.

I've not yet tested this on the Voice Kit hardware (or even on a machine with a microphone - I only have access to a Chromebook right now). I'm concerned that upgrading the library breaks the button+library demo as reported in #204. However, that's separate to the Device / Model ID logic.

The Device ID is currently unused, but it may be required for the gRPC API, and would be required if we want to use Device Actions, so it makes sense to keep it.

@proppy, how can we specify the language? I can't see any way to specify it for the Google Assistant Library, and the gRPC docs still say [only en-US is supported](https://developers.google.com/assistant/sdk/reference/rpc/google.assistant.embedded.v1alpha2#encoding).