### PR TITLE
Remove hardcoded path references

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -32,8 +32,7 @@ sudo pip3 install --upgrade pip virtualenv
 cd "${scripts_dir}/.."
 virtualenv --system-site-packages -p python3 env
 env/bin/pip install -r requirements.txt
-echo "/home/pi/AIY-projects-python/src" > \
-  /home/pi/AIY-projects-python/env/lib/python3.5/site-packages/aiy.pth
+echo "$(pwd)/src" > ./env/lib/python3.5/site-packages/aiy.pth
 
 # The google-assistant-library is only available on ARMv7.
 if [[ "$(uname -m)" == "armv7l" ]] ; then


### PR DESCRIPTION
Remove the assumed /home/pi/AIY-projects-python project path. This is
easily done because of the previous cd call change the CWD to the
project path. This changed is needed because of conflicting instructions
in HACKING.md This resolves
https://github.com/google/aiyprojects-raspbian/issues/211