### PR TITLE
Run check_audio in python env

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -39,7 +39,7 @@ After your Pi has rebooted with the driver enabled, run:
 ```
 cd ~/AIY-projects-python
 sudo scripts/install-alsa-config.sh
-python3 checkpoints/check_audio.py
+sudo env/bin/python checkpoints/check_audio.py
 sudo reboot
 ```
 


### PR DESCRIPTION
The documented command is missing the env and this is what happend:  

```
Traceback (most recent call last):
  File "checkpoints/check_audio.py", line 27, in <module>
    import aiy.audio  # noqa
ImportError: No module named 'aiy'
```

I changed it to the command that can be found in `shortcuts/check_audio.desktop`