### PR TITLE
Also install google-assistant-library on armv6l

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -35,7 +35,7 @@ env/bin/pip install -r requirements.txt
 echo "/home/pi/AIY-projects-python/src" > \
   /home/pi/AIY-projects-python/env/lib/python3.5/site-packages/aiy.pth
 
-# The google-assistant-library is only available on ARMv7.
-if [[ "$(uname -m)" == "armv7l" ]] ; then
+# The google-assistant-library is only available on ARMv7 and ARMv6.
+if [[ "$(uname -m)" == "armv7l" || "$(uname -m)" == "armv6l" ]] ; then
   env/bin/pip install google-assistant-library==0.0.3
 fi


### PR DESCRIPTION
I'm running a raspberry pi zero w (arm6l). I've done all the setup steps. 
When running the example scripts, the `google-assistant-library` was missing. So I installed it the same way like in the install-deps.sh does it for ARMv7 and it works fine. So this I guess it's not only available on v7 but on v6?