### PR TITLE
Fixing LED deadlock

### DIFF
--- a/src/aiy/_drivers/_led.py
+++ b/src/aiy/_drivers/_led.py
@@ -69,8 +69,9 @@ class LED:
         with self.lock:  # pylint: disable=E1129
             if self.running:
                 self.running = False
-                self.animator.join()
-                self.pwm.stop()
+
+        self.animator.join()
+        self.pwm.stop()
 
     def set_state(self, state):
         """Set the LED driver's new state.

--- a/src/aiy/_drivers/_led.py
+++ b/src/aiy/_drivers/_led.py
@@ -70,7 +70,12 @@ class LED:
             if self.running:
                 self.running = False
 
-        self.animator.join()
+        try:
+            self.animator.join()
+        except RuntimeError:
+            # Edge case where this is stopped before it starts.
+            pass
+
         self.pwm.stop()
 
     def set_state(self, state):


### PR DESCRIPTION
## Description

During the LED cleanup process, a deadlock occurs as illustrated below. In this example, Thread A is the main thread which calls `LED.stop()`, and Thread B is the animate thread, held by `self.animator`.

1. `LED.stop()` is called by Thread A.
2. Thread A acquires the lock ([L69](https://github.com/google/aiyprojects-raspbian/blob/aiyprojects/src/aiy/_drivers/_led.py#L69))
3. It joins with Thread B, without releasing the lock. ([L72](https://github.com/google/aiyprojects-raspbian/blob/aiyprojects/src/aiy/_drivers/_led.py#L72))
4. Thread B waits for the lock, before being able to terminating. ([L87](https://github.com/google/aiyprojects-raspbian/blob/aiyprojects/src/aiy/_drivers/_led.py#L87))

This was reproduced in Python 3.5.3.

By moving the join statement outside the `with` block, we release the lock before trying to join to that thread, and everything works out well.

## Testing

Manually tested.