### PR TITLE
Update bpm calculation at toneplayer.py

### DIFF
--- a/src/aiy/toneplayer.py
+++ b/src/aiy/toneplayer.py
@@ -42,7 +42,7 @@ class Rest(object):
 
     def to_length_secs(self):
         """Converts from musical notation to a period of time in seconds."""
-        return (self.bpm / 60.0) / self.period
+        return ( 60.0 / self.bpm ) / self.period
 
 
 class Note(Rest):


### PR DESCRIPTION
Currently the lower the bpm, the faster the speed. The opposite should be true instead.
Changed to calculation to : The higher the bpm, the faster the speed.