### PR TITLE
Add missing dependency to setup.py

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -16,6 +16,7 @@ setup(
     install_requires=[
         'google-assistant-grpc==0.1.0',
         'google-assistant-library==0.1.0',
+        'google-auth-oauthlib==0.2.0',
         'google-cloud-speech==0.30.0',
         'gpiozero',
         'paho-mqtt',


### PR DESCRIPTION
Currently if you follow the instructions in HACKING.md to install Assistant, you will end up with a broken install. When you try to run any of the demos, you will get an error because the dependency `google-auth-oauthlib` is missing. This was formerly listed as a dependency in the `requirements.txt` file when there was one, I think it still needs to be there in `setup.py`.