### PR TITLE
Fix a potential UnboundLocalError in tests

### DIFF
--- a/src/tests/test_util.py
+++ b/src/tests/test_util.py
@@ -23,12 +23,9 @@ def test_image_path(name):
 
 @contextmanager
 def TestImage(name):
-    try:
-        f = open(test_image_path(name), 'rb')
+    with open(test_image_path(name), 'rb') as f:
+        image = Image.open(f)
         try:
-            image = Image.open(f)
             yield image
         finally:
             image.close()
-    finally:
-        f.close()


### PR DESCRIPTION
```python
name = 'hotdog.jpg'

    @contextmanager
    def TestImage(name):
        try:
            f = open(test_image_path(name), 'rb')
            try:
                image = Image.open(f)
                yield image
            finally:
                image.close()
        finally:
>           f.close()
E           UnboundLocalError: local variable 'f' referenced before assignment
```
Using the context manager will always do the work for us :)

The same error could happen  for `image`, fixed in the same time.