### PR TITLE
Fixed auth_helpers.py to work with Python 3.7

### DIFF
--- a/src/aiy/assistant/auth_helpers.py
+++ b/src/aiy/assistant/auth_helpers.py
@@ -72,7 +72,7 @@ def _credentials_flow_interactive(client_secrets_path):
         # Use chromium-browser by default. Raspbian Stretch uses Epiphany by
         # default but that seems to cause issues:
         # https://github.com/google/aiyprojects-raspbian/issues/269
-        webbrowser.register('chromium-browser', None, webbrowser.Chrome('chromium-browser'), -1)
+        webbrowser.register('chromium-browser', None, webbrowser.Chrome('chromium-browser'), preferred=True)
         credentials = flow.run_local_server()
     else:
         credentials = flow.run_console()


### PR DESCRIPTION
This commit fixes a bug where the web browser doesn't open properly because of improper syntax for Python 3.7. The improper call of webbrowser.register in [auth_helpers.py](https://github.com/google/aiyprojects-raspbian/blob/aiyprojects/src/aiy/assistant/auth_helpers.py) causes the entire authentication to fail, which prevents the user from starting any of the example programs. This only happens when the user tries to authenticate using the desktop interface. When the user uses ssh, the problem is avoided.

The [change](https://github.com/google/aiyprojects-raspbian/compare/aiyprojects...daOrangePeeler:aiyprojects#diff-8db3fedb90581253d5da05a8a902ca07) in [auth_helpers.py](https://github.com/google/aiyprojects-raspbian/blob/aiyprojects/src/aiy/assistant/auth_helpers.py) is on line 75 and the last argument is changed from "-1" to "preferred=True." The [documentation](https://docs.python.org/3/library/webbrowser.html#webbrowser.register) explains that the last argument takes boolean values instead of numeric values. This [comment](https://github.com/google/aiyprojects-raspbian/issues/658#issuecomment-568777735) also explains how to implement the fix.

Resolves #658.