### PR TITLE
docs: fix simple typo, implemenation -> implementation

### DIFF
--- a/src/examples/gpiozero/button_example.py
+++ b/src/examples/gpiozero/button_example.py
@@ -2,7 +2,7 @@
 """Example code that demonstrates using a standard pin along with a hat pin.
 
 The button uses a standard GPIO pin through the raspberry pi's memory mapped io,
-while the led uses the hat's sysfs driver. This implemenation difference is
+while the led uses the hat's sysfs driver. This implementation difference is
 transparent to the user.
 
 The demo will light up the on board LED whenever the user presses the button.

--- a/src/examples/gpiozero/simple_button_example.py
+++ b/src/examples/gpiozero/simple_button_example.py
@@ -2,7 +2,7 @@
 """Example code that demonstrates using a standard pin along with a hat pin.
 
 The button uses a standard GPIO pin through the raspberry pi's memory mapped io,
-while the led uses the hat's sysfs driver. This implemenation difference is
+while the led uses the hat's sysfs driver. This implementation difference is
 transparent to the user.
 
 The demo will light up the on board LED whenever the user presses the button.


### PR DESCRIPTION
There is a small typo in src/examples/gpiozero/button_example.py, src/examples/gpiozero/simple_button_example.py.

Should read `implementation` rather than `implemenation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md