### PR TITLE
Change add_stylesheet to add_css_file 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,7 +146,7 @@ html_static_path = ['_static']
 
 # Add our custom stylesheet. By default, Sphinx looks for this in _static/.
 def setup(app):
-    app.add_stylesheet('custom.css')
+    app.add_css_file('custom.css')
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
...as the former was deprecated in Sphinx 1.8.

Reference: https://www.sphinx-doc.org/en/master/extdev/appapi.html?highlight=add_css#sphinx.application.Sphinx.add_css_file