### PR TITLE
Fix dependency version problem in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     install_requires=[
         'google-assistant-library>=1.0.1',
         'google-assistant-grpc>=0.2.0',
-        'google-auth>=1.5.1',
         'google-auth-oauthlib>=0.2.0',
         'google-cloud-speech>=0.36.0',
         'gpiozero',


### PR DESCRIPTION
When trying to install this package I got an error informing me that `google-assistant-library 1.1.0 has requirement google-auth<2,>=1.0.1, but you'll have google-auth 2.3.0 which is incompatible`. Removing the top-level dependency on the google-auth package lets google-assistant-library's transitive deps bring in a working version of google-auth.

cf. https://github.com/google/aiyprojects-raspbian/issues/746